### PR TITLE
docs(readme): add pins of Mara X board

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ An arduino based shot timer for the Lelit Mara X prosumer espressor machine.
 
 # Power supply
 
+## Pins
+
+* 0 - VCC (12V)
+* 1 - GND
+* 3 - Receive (RX)
+* 4 - Transmit (TX)
+
 ## USB
 
 ## 9V block battery


### PR DESCRIPTION
The Mara X board has pins on the bottom side of the box. Two of them (TX and RX) are always documented. This PR adds two pins that I found by testing a suspicion. 